### PR TITLE
h3タグの高さを調整し、リンク遷移時にnavbarと干渉しないよう修正

### DIFF
--- a/03/src/scss/style.scss
+++ b/03/src/scss/style.scss
@@ -15,3 +15,8 @@ a {
 a:hover {
   color: $gold-dark;
 }
+
+.container>h3 {
+  padding-top: 4rem;
+  margin-top: -4rem;
+}


### PR DESCRIPTION
## やったこと

ページ内リンクによる移動の際に、文章とnavbarがかぶる問題を修正しました。

* before
![cap2](https://user-images.githubusercontent.com/2376843/42821847-7595701a-8a14-11e8-85f6-74525edf8040.gif)
* after
![cap1](https://user-images.githubusercontent.com/2376843/42822106-24af36a8-8a15-11e8-8225-aa47c1894d35.gif)


