### PR TITLE
Fix author order

### DIFF
--- a/2023/src/yaml/data.yaml
+++ b/2023/src/yaml/data.yaml
@@ -325,14 +325,14 @@ sessions:
         name: 最知 庸
       - member_of: NTT 東日本
         name: 小林 丈之
-      - member_of: NTT 東日本
-        name: 阪内 澄宇
       - member_of: 東音企画
         name: 笹生 恵理
       - member_of: ピティナ
         name: 山内 竣平
       - member_of: ピティナ
         name: 野口 啓之
+      - member_of: NTT 東日本
+        name: 阪内 澄宇
     tags:
       - Application
       - DX


### PR DESCRIPTION
講演者の順番ですが阪内を一番最後にしていただけないでしょうか。
（細田、最知、小林、笹生、山内、野口、阪内の順番）
あまり意味はないのかもしれませんが FIT2022 にて学会発表したときの著者順を踏襲したいという意図があります。アカデミックな方面の習慣に従った順番（ラストオーサー＝阪内が総責任者を意味する）になっております。

FIT2022 の時の順番は
https://onsite.gakkai-web.net/fit2022/abstract/data/html/program/e.html
の CE-007 のところにあります。