### PR TITLE
Set 2025 deploy config

### DIFF
--- a/.github/workflows/deploy-to-github-pages.yml
+++ b/.github/workflows/deploy-to-github-pages.yml
@@ -5,7 +5,7 @@ on:
       - master
 env:
   NODE_VERSION: 20
-  WORKING_DIRECTORY: "2024"
+  WORKING_DIRECTORY: "2025"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@
 - [NTT Tech Conference 2022](https://ntt-developers.github.io/ntt-tech-conference/2022/)
 - [NTT Tech Conference 2023](https://ntt-developers.github.io/ntt-tech-conference/2023/)
 - [NTT Tech Conference 2024](https://ntt-developers.github.io/ntt-tech-conference/2024/)
+- [NTT Tech Conference 2025](https://ntt-developers.github.io/ntt-tech-conference/2025/)


### PR DESCRIPTION
This pull request includes updates to the `WORKING_DIRECTORY` environment variable and the `README.md` file to reflect the upcoming year.

Changes include:

* [`.github/workflows/deploy-to-github-pages.yml`](diffhunk://#diff-ff49704c25d08d294e707839cc3d2831fbf4a6eada505c46b721163df00981eaL8-R8): Updated the `WORKING_DIRECTORY` environment variable from "2024" to "2025".
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11): Added a link for the NTT Tech Conference 2025.